### PR TITLE
ci: debug-insecure-cipher-paratime -> localnet-cipher-paratime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.21.x"
 
@@ -28,7 +28,7 @@ jobs:
         id: build-debug-elf
         uses: oasisprotocol/oasis-sdk/.github/actions/hash-rust@main
         with:
-          image: oasisprotocol/runtime-builder:main
+          image: ghcr.io/oasisprotocol/runtime-builder:main
           pkg-dirs: runtime
           binaries: cipher-paratime
           clean: no
@@ -39,7 +39,7 @@ jobs:
         run: |
           go install github.com/oasisprotocol/oasis-sdk/tools/orc@latest
           pushd runtime
-          orc init ${RUNTIME_EXECUTABLE} --output ../insecure-debug-cipher-paratime.orc
+          orc init ${RUNTIME_EXECUTABLE} --output ../localnet-cipher-paratime.orc
           popd
         env:
           RUNTIME_EXECUTABLE: ${{ github.workspace }}/${{ steps.build-debug-elf.outputs.build-path }}/cipher-paratime
@@ -48,7 +48,7 @@ jobs:
         id: build-elf
         uses: oasisprotocol/oasis-sdk/.github/actions/hash-rust@main
         with:
-          image: oasisprotocol/runtime-builder:main
+          image: ghcr.io/oasisprotocol/runtime-builder:main
           pkg-dirs: runtime
           binaries: cipher-paratime
           clean: no
@@ -57,7 +57,7 @@ jobs:
         id: build-sgxs
         uses: oasisprotocol/oasis-sdk/.github/actions/hash-rust@main
         with:
-          image: oasisprotocol/runtime-builder:main
+          image: ghcr.io/oasisprotocol/runtime-builder:main
           pkg-dirs: runtime
           binaries: cipher-paratime.sgxs
           clean: no
@@ -79,5 +79,5 @@ jobs:
         with:
           # Create a draft since the release requires an offline signing process.
           draft: true
-          artifacts: cipher-paratime.orc,insecure-debug-cipher-paratime.orc
+          artifacts: cipher-paratime.orc,localnet-cipher-paratime.orc
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR:
- renames `insecure-debug-cipher-paratime.orc` to `localnet-cipher-paratime.orc` for consistency with other ParaTime releases.

### Some thoughts

The prefix `localnet-` implies it is to be run locally e.g. for testing, inside the CI, docker image etc. The incentive for this originated from EVM that uses the notion of _chain ID_ and is baked in the Emerald and Sapphire ParaTime binary. On the client side MetaMask uses the chain ID to determine which web3 gateway IP it will try to connect to. So we decided that the localnet's chain ID will be the one pointing to 127.0.0.1. This way you change the behavior of your dApp by simply changing the chain ID in the config and then deployment, tests etc. will use a different network.

Cipher does not have the chain ID notion. In theory, could you use the insecure Cipher binary to set up a perfectly valid non-confidential oasis-wasm chain **on the network**? In this case the `localnet-` term may be less suitable. How does a Cipher dApp know which network to use? The combination of gRPC endpoing address + the Runtime ID? But the Runtime ID is not baked into the binary, right?